### PR TITLE
Rotate an image based on the EXIF orientation tag before deleting all EXIF tags.

### DIFF
--- a/exif_delete.py
+++ b/exif_delete.py
@@ -23,6 +23,7 @@ import os
 import sys
 # third-party libraries
 from PIL import Image
+from PIL import ImageOps
 
 
 def main(argz=[]):
@@ -105,6 +106,9 @@ def exif_delete(original_file_path, new_file_path):
     except IOError:
         print('ERROR: Problem reading image file. ' + str(original_file_path))
         return
+
+    # Rotate image to correct orientation before removing EXIF data
+    original = ImageOps.exif_transpose(original)
 
     # create output image, forgetting the EXIF metadata
     stripped = Image.new(original.mode, original.size)


### PR DESCRIPTION
When EXIF tags are stripped the viewing orientation (landscape, portrait) is stripped as well. This can result in images begin shown on their side.

To prevent that I added one line that transforms (rotates) the image based on its EXIF orientation tag before all EXIF tags are scrapped.